### PR TITLE
change the sequence of show and savefig to avoid blank image being st…

### DIFF
--- a/pytopdrawer/pytopdrawer.py
+++ b/pytopdrawer/pytopdrawer.py
@@ -40,8 +40,8 @@ def main():
 			ti += 1
 			if ti == N:
 				break
-
+	if args.output is not None:
+		fig.savefig(args.output)
 	if not args.noshow:
 		plt.show()
-	if args.output is not None:
-		plt.savefig(args.output)
+


### PR DESCRIPTION
When using the --output argument a blank image is stored if --noshow is not used. By inverting the sequence of showing and saving this is avoided.